### PR TITLE
Prediction Timer Fix

### DIFF
--- a/src/app/prediction-render/prediction-render.component.ts
+++ b/src/app/prediction-render/prediction-render.component.ts
@@ -110,16 +110,19 @@ export class PredictionRenderComponent implements OnInit {
     let minutes;
     let seconds;
     const updateTimer = () => {
-      minutes = Math.floor(timer / 60);
-      seconds = timer % 60;
+      if (timer >= 0) {
+        minutes = Math.floor(timer / 60);
+        seconds = timer % 60;
 
-      minutes = minutes < 10 ? "0" + minutes : minutes;
-      seconds = seconds < 10 ? "0" + seconds : seconds;
+        minutes = minutes < 10 ? "0" + minutes : minutes;
+        seconds = seconds < 10 ? "0" + seconds : seconds;
 
-      this.predictionTimer = minutes + ":" + seconds;
+        this.predictionTimer = minutes + ":" + seconds;
+      }
 
       if (--timer < 0) {
-        timer = 0;
+        timer = -1;
+        this.predictionTimer = "00:00";
         clearInterval(this.timerInterval);
       }
     }


### PR DESCRIPTION
Prediction component now checks to make sure timer value is a non-negative number before calculating values and updating the timer. Once timer hits 0, it is now set to -1 to prevent unnecessary calculations and the timer is set to "00:00" just in case. This fixes the occasional negative numbers in the prediction timer.

Courtesy of thesilverone on Discord