### PR TITLE
Implement Spotify "Now Playing" Overlay Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^16.1.7",
         "@angular/platform-browser-dynamic": "^16.1.7",
         "@angular/router": "^16.1.7",
+        "@spotify/web-api-ts-sdk": "^1.2.0",
         "@types/howler": "^2.2.7",
         "@types/voice-activity-detection": "^0.0.2",
         "chess.js": "^1.0.0-beta.6",
@@ -38,7 +39,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
-        "typescript": "~4.9.5"
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -198,6 +199,22 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@ngtools/webpack": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.1.6.tgz",
+      "integrity": "sha512-rDE1bV3+Ys/VyeD6l7JKtbs3+bTQAfWhi7meEuq5mkaJHOERu6Z40ce866faAIX2I1AVpsSv8rLlb7kB7t7kzw==",
+      "dev": true,
+      "engines": {
+        "node": "^16.14.0 || >=18.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": "^16.0.0",
+        "typescript": ">=4.9.3 <5.2",
+        "webpack": "^5.54.0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/lru-cache": {
@@ -2924,22 +2941,6 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
-    "node_modules/@ngtools/webpack": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.1.6.tgz",
-      "integrity": "sha512-rDE1bV3+Ys/VyeD6l7JKtbs3+bTQAfWhi7meEuq5mkaJHOERu6Z40ce866faAIX2I1AVpsSv8rLlb7kB7t7kzw==",
-      "dev": true,
-      "engines": {
-        "node": "^16.14.0 || >=18.10.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler-cli": "^16.0.0",
-        "typescript": ">=4.9.3 <5.2",
-        "webpack": "^5.54.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3178,6 +3179,11 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
+    },
+    "node_modules/@spotify/web-api-ts-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spotify/web-api-ts-sdk/-/web-api-ts-sdk-1.2.0.tgz",
+      "integrity": "sha512-JUaebva3Ohwo5I5tuTqyW/FKGOMbb40YevJMySAOINRxP7qQ/AMjBzfJx0zeO6yS+wAPfQSoGNsZaUggHw8vsA=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -10758,16 +10764,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "^16.1.7",
     "@angular/platform-browser-dynamic": "^16.1.7",
     "@angular/router": "^16.1.7",
+    "@spotify/web-api-ts-sdk": "^1.2.0",
     "@types/howler": "^2.2.7",
     "@types/voice-activity-detection": "^0.0.2",
     "chess.js": "^1.0.0-beta.6",
@@ -41,6 +42,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "typescript": "~4.9.5"
+    "typescript": "^5.1.6"
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,6 +12,7 @@ import { StreamLayoutComponent } from './stream-layout/stream-layout.component';
 import { ChatComponent } from './chat/chat.component';
 import { ConnectFourComponent } from './connect-four/connect-four.component';
 import { ViewerComponent } from './viewer/viewer.component';
+import { SpotifyComponent } from './spotify-nowplaying/spotify-nowplaying.component';
 
 const routes: Routes = [
     {
@@ -65,6 +66,10 @@ const routes: Routes = [
     {
         path: "viewer",
         component: ViewerComponent
+    },
+    {
+        path: "spotify",
+        component: SpotifyComponent
     }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { AiChatInteractorComponent } from './ai-chat-interactor/ai-chat-interact
 import { ChatMessageComponent } from './chat-message/chat-message.component';
 import { FormsModule } from '@angular/forms';
 import { ViewerComponent } from './viewer/viewer.component';
+import { SpotifyComponent } from './spotify-nowplaying/spotify-nowplaying.component';
 
 @NgModule({
   declarations: [
@@ -81,7 +82,8 @@ import { ViewerComponent } from './viewer/viewer.component';
     AnimationComponent,
     AiChatInteractorComponent,
     ChatMessageComponent,
-    ViewerComponent
+    ViewerComponent,
+    SpotifyComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/services/spotify.service.ts
+++ b/src/app/services/spotify.service.ts
@@ -11,7 +11,7 @@ export class SpotifyService {
   isAuthenticated: boolean = false;
 
   constructor() {
-    this.sdk = SpotifyApi.prototype;
+    this.sdk = SpotifyApi.withUserAuthorization(environment.spotifyClientID, environment.spotifyRedirectURL, ["user-read-currently-playing"]);
     if (this.sdk.getAccessToken !== null) { // If we have an access token already, don't go through login flow again
       this.isAuthenticated == true;
     }
@@ -25,7 +25,6 @@ export class SpotifyService {
   }
 
   async login() {
-    this.sdk = SpotifyApi.withUserAuthorization(environment.spotifyClientID, environment.spotifyRedirectURL, ["user-read-currently-playing"]);
     const { authenticated } = await this.sdk.authenticate();
 
     if (!authenticated) {

--- a/src/app/services/spotify.service.ts
+++ b/src/app/services/spotify.service.ts
@@ -1,0 +1,47 @@
+import { SpotifyApi } from "@spotify/web-api-ts-sdk";
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SpotifyService {
+
+  sdk: SpotifyApi;
+  isAuthenticated: boolean = false;
+
+  constructor() {
+    this.sdk = SpotifyApi.prototype;
+    if (this.sdk.getAccessToken !== null) {
+      this.isAuthenticated == true;
+    }
+  }
+
+  async getNowPlaying() {
+    if (this.isAuthenticated) {
+      return this.sdk.player.getCurrentlyPlayingTrack();
+    }
+    return "AuthError";
+  }
+
+  async login() {
+    this.sdk = SpotifyApi.withUserAuthorization(environment.spotifyClientID, environment.spotifyRedirectURL, ["user-read-currently-playing"]);
+    const { authenticated } = await this.sdk.authenticate();
+
+    if (!authenticated) {
+      console.log("Error authenticating with Spotify");
+    } else {
+      console.log("Spotify Auth Successful");
+      this.isAuthenticated = true;
+    }
+  }
+
+  async logoff() {
+    this.isAuthenticated = false;
+  }
+
+  getAuthStatus() {
+    return this.isAuthenticated;
+  }
+
+}

--- a/src/app/services/spotify.service.ts
+++ b/src/app/services/spotify.service.ts
@@ -12,7 +12,8 @@ export class SpotifyService {
 
   constructor() {
     this.sdk = SpotifyApi.withUserAuthorization(environment.spotifyClientID, environment.spotifyRedirectURL, ["user-read-currently-playing"]);
-    if (this.sdk.getAccessToken !== null) { // If we have an access token already, don't go through login flow again
+    // If we have an access token already, don't go through login flow again
+    if (this.sdk.getAccessToken !== null) {
       this.isAuthenticated == true;
     }
   }

--- a/src/app/services/spotify.service.ts
+++ b/src/app/services/spotify.service.ts
@@ -12,7 +12,7 @@ export class SpotifyService {
 
   constructor() {
     this.sdk = SpotifyApi.prototype;
-    if (this.sdk.getAccessToken !== null) {
+    if (this.sdk.getAccessToken !== null) { // If we have an access token already, don't go through login flow again
       this.isAuthenticated == true;
     }
   }
@@ -21,7 +21,7 @@ export class SpotifyService {
     if (this.isAuthenticated) {
       return this.sdk.player.getCurrentlyPlayingTrack();
     }
-    return "AuthError";
+    return false;
   }
 
   async login() {
@@ -31,12 +31,12 @@ export class SpotifyService {
     if (!authenticated) {
       console.log("Error authenticating with Spotify");
     } else {
-      console.log("Spotify Auth Successful");
+      console.log("Spotify Auth successful");
       this.isAuthenticated = true;
     }
   }
 
-  async logoff() {
+  async stop() {
     this.isAuthenticated = false;
   }
 

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.html
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.html
@@ -1,4 +1,4 @@
-<div class="spotify-animation" [@slideUp] *ngIf="!complete">
+<div class="spotify-animation" [@slideUp] *ngIf="playing">
     <div style="background-image: url('assets/RankBackgrounds/player-vod-bg.png');">
         <div class="song-display">
             <div class="album-cover" *ngIf="albumCoverURL !== ''">
@@ -17,5 +17,5 @@
     </div>
 </div>
 
-<ng-container *ngIf="complete">
+<ng-container *ngIf="!playing">
 </ng-container>

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.html
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.html
@@ -1,0 +1,21 @@
+<div class="spotify-animation" [@slideUp] *ngIf="!complete">
+    <div style="background-image: url('assets/RankBackgrounds/player-vod-bg.png');">
+        <div class="song-display">
+            <div class="album-cover" *ngIf="albumCoverURL !== ''">
+                <img class="rank-image" [src]="albumCoverURL">
+            </div>
+
+            <div class="names">
+                <div class="song-name">
+                    {{songTitle}}
+                </div>
+                <div class="artist-name">
+                    {{songArtist}}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<ng-container *ngIf="complete">
+</ng-container>

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.html
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.html
@@ -2,9 +2,8 @@
     <div style="background-image: url('assets/RankBackgrounds/player-vod-bg.png');">
         <div class="song-display">
             <div class="album-cover" *ngIf="albumCoverURL !== ''">
-                <img class="rank-image" [src]="albumCoverURL">
+                <img class="cover-image" [src]="albumCoverURL">
             </div>
-
             <div class="names">
                 <div class="song-name">
                     {{songTitle}}
@@ -12,6 +11,8 @@
                 <div class="artist-name">
                     {{songArtist}}
                 </div>
+            </div>
+            <div class="song-progress" [ngStyle]="{ width: songProgressPercent }">
             </div>
         </div>
     </div>

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.scss
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.scss
@@ -36,7 +36,7 @@
   /* H3 - Bold */
   text-align: left;
   font-family: 'Montserrat';
-  font-size: 14px;
+  font-size: 12px;
   font-style: normal;
   font-weight: 900;
   line-height: normal;
@@ -52,7 +52,7 @@
   font-variant-numeric: lining-nums tabular-nums;
   /* Label 1 */
   font-family: 'Montserrat';
-  font-size: 16px;
+  font-size: 14px;
   font-style: normal;
   font-weight: 700;
   line-height: normal;
@@ -65,4 +65,12 @@
   position: absolute;
   right: 10px;
   top: 5px;
+}
+
+.song-progress {
+  position: absolute;
+  width: 0%;
+  height: 5px;
+  background-color: #1BD760;
+  bottom: 0;
 }

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.scss
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.scss
@@ -1,0 +1,68 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap');
+
+@keyframes up {
+  from {
+    padding-top: 74px;
+  }
+
+  to {
+    padding-top: 0px;
+  }
+}
+
+.song-display {
+  width: 274px;
+  height: 74px;
+  display: flex;
+  filter: drop-shadow(3px 3px 8px black);
+}
+
+.box {
+  display: flex;
+  justify-content: center;
+}
+
+.names {
+  padding-top: 8px;
+  padding-right: 19px;
+  padding-left: 5px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.artist-name {
+  color: #1BD760;
+  /* H3 - Bold */
+  text-align: left;
+  font-family: 'Montserrat';
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 900;
+  line-height: normal;
+  text-transform: uppercase;
+  inline-size: 170px;
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.song-name {
+  color: var(--chat-msg);
+  text-align: left;
+  font-variant-numeric: lining-nums tabular-nums;
+  /* Label 1 */
+  font-family: 'Montserrat';
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  inline-size: 170px;
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.album-cover {
+  position: absolute;
+  right: 10px;
+  top: 5px;
+}

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -56,8 +56,13 @@ export class SpotifyComponent implements OnInit {
     });
 
     this.botService.getStream("vod-reviews").subscribe(data => {
-      // If there is an active VOD Review, don't render Spotify
-      this.vodReviewActive = data.complete ? false : true;
+      // If a VOD Review is set as "complete", we're no longer blocked
+      if (data.complete === true) {
+        this.vodReviewActive = false;
+      } else { // Else block rendering
+        this.playing = false;
+        this.vodReviewActive = true;
+      }
     });
   }
 

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -67,7 +67,7 @@ export class SpotifyComponent implements OnInit {
       if (nowPlaying.item.type == "track") {
         const item = nowPlaying.item as Track; // Needed because TS complains that we might be working with a "Episode" otherwise
 
-        const albumArt = item.album.images.pop();
+        const albumArt = item.album.images.pop(); // Getting the last image from this array will give us the 64x64 version, perfect for our overlay
         this.albumCoverURL = albumArt ? albumArt.url : "assets/hoojsheesh.png"; // Assume self-composed for local files, which will return no album art
 
         this.songArtist = item.artists[0].name;

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -1,0 +1,82 @@
+import { Component, OnInit } from '@angular/core';
+import { trigger, style, transition, animate } from '@angular/animations';
+import { SpotifyService } from '../services/spotify.service';
+import { BotConnectorService } from '../services/bot-connector.service';
+import { PlaybackState, Track } from '@spotify/web-api-ts-sdk';
+
+const LOOP_INTERVAL = 5 * 1000; // 5 seconds
+
+@Component({
+  selector: 'app-spotify',
+  templateUrl: './spotify-nowplaying.component.html',
+  styleUrls: ['./spotify-nowplaying.component.scss'],
+  animations: [
+    trigger('slideUp', [
+      transition(':enter', [
+        style({ 'padding-top': '100px' }),
+        animate('1s ease-out', style({ 'padding-top': '0px' }))
+      ]),
+
+      transition(':leave',
+        animate('1s ease-out', style({ 'padding-top': '100px' }))
+      )
+    ])
+  ]
+})
+export class SpotifyComponent implements OnInit {
+
+  constructor(private botService: BotConnectorService, private spotifyService: SpotifyService) {
+  }
+
+  complete: boolean = true;
+  active: boolean = false;
+  albumCoverURL: string = "";
+  songTitle: string = "";
+  songArtist: string = "";
+
+  ngOnInit(): void {
+    this.botService.getStream("streamdeck").subscribe(async data => {
+      if (data.type === "spotify") {
+        if (data.name === "login" && data.value == true) {
+          await this.spotifyService.login();
+          this.active = true;
+          this.nowPlayingLoop();
+        } else if (data.name === "logoff" && data.value == true) {
+          await this.spotifyService.logoff();
+          this.active = false;
+          this.complete = true;
+        }
+      }
+    });
+  }
+
+  async nowPlayingLoop() {
+    if (this.active) {
+      await this.loadNowPlaying();
+      setTimeout(() => this.nowPlayingLoop(), LOOP_INTERVAL);
+    }
+  }
+
+  async loadNowPlaying() {
+    const nowPlaying: PlaybackState | "AuthError" = await this.spotifyService.getNowPlaying();
+    if (nowPlaying == "AuthError") {
+      this.complete = true;
+      return;
+    } else {
+      if (nowPlaying.item.type == "track") {
+        const item = nowPlaying.item as Track;
+
+        const albumArt = item.album.images.pop();
+        this.albumCoverURL = albumArt ? albumArt.url : "assets/hoojsheesh.png"; // Assume self-composed for local files, which will return no album art
+
+        this.songArtist = item.artists[0].name;
+        this.songTitle = item.name;
+
+        this.complete = false;
+      } else {
+        this.complete = true;
+      }
+    }
+  }
+
+}

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -56,7 +56,8 @@ export class SpotifyComponent implements OnInit {
     });
 
     this.botService.getStream("vod-reviews").subscribe(data => {
-      this.vodReviewActive = !data.complete;
+      // If there is an active VOD Review, don't render Spotify
+      this.vodReviewActive = data.complete ? false : true;
     });
   }
 

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -67,8 +67,12 @@ export class SpotifyComponent implements OnInit {
       if (nowPlaying.item.type == "track") {
         const item = nowPlaying.item as Track; // Needed because TS complains that we might be working with a "Episode" otherwise
 
-        const albumArt = item.album.images.pop(); // Getting the last image from this array will give us the 64x64 version, perfect for our overlay
-        this.albumCoverURL = albumArt ? albumArt.url : "assets/hoojsheesh.png"; // Assume self-composed for local files, which will return no album art
+        if (item.is_local) { // If the file is local, assume self-composed - display a (for now placeholder) hoojSheesh
+          this.albumCoverURL = "assets/hoojsheesh.png";
+        } else {
+          const albumArt = item.album.images.pop(); // Getting the last image from this array will give us the 64x64 version, perfect for our overlay
+          this.albumCoverURL = albumArt ? albumArt.url : "";
+        }
 
         this.songArtist = item.artists[0].name;
         this.songTitle = item.name;

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -30,6 +30,7 @@ export class SpotifyComponent implements OnInit {
 
   playing: boolean = false; // Whether or not to show the Overlay
   active: boolean = false; // Whether or not to continue the loop
+  vodReviewActive: boolean = false;
   albumCoverURL: string = "";
   songTitle: string = "";
   songArtist: string = "";
@@ -52,6 +53,10 @@ export class SpotifyComponent implements OnInit {
         }
       }
     });
+
+    this.botService.getStream("vod-reviews").subscribe(data => {
+      this.vodReviewActive = !data.complete;
+    });
   }
 
   // Check for currently playing song every LOOP_INTERVAL millis
@@ -70,6 +75,11 @@ export class SpotifyComponent implements OnInit {
   }
 
   async loadNowPlaying() {
+    if (this.vodReviewActive) {
+      this.playing = false;
+      return;
+    }
+
     const nowPlaying: PlaybackState | false = await this.spotifyService.getNowPlaying();
     if (!nowPlaying || !nowPlaying.is_playing) {
       this.playing = false;

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -28,7 +28,7 @@ export class SpotifyComponent implements OnInit {
   constructor(private botService: BotConnectorService, private spotifyService: SpotifyService) {
   }
 
-  complete: boolean = true; // Whether or not to show the Overlay
+  playing: boolean = false; // Whether or not to show the Overlay
   active: boolean = false; // Whether or not to continue the loop
   albumCoverURL: string = "";
   songTitle: string = "";
@@ -43,7 +43,7 @@ export class SpotifyComponent implements OnInit {
           this.nowPlayingLoop();
         } else if (data.name === "stop" && data.value == true) {
           await this.spotifyService.stop();
-          this.complete = true;
+          this.playing = false;
           this.active = false;
         }
       }
@@ -60,7 +60,7 @@ export class SpotifyComponent implements OnInit {
   async loadNowPlaying() {
     const nowPlaying: PlaybackState | false = await this.spotifyService.getNowPlaying();
     if (!nowPlaying || !nowPlaying.is_playing) {
-      this.complete = true;
+      this.playing = false;
       return;
     } else {
       if (nowPlaying.item.type == "track") {
@@ -76,9 +76,9 @@ export class SpotifyComponent implements OnInit {
         this.songArtist = item.artists[0].name;
         this.songTitle = item.name;
 
-        this.complete = false;
+        this.playing = true;
       } else {
-        this.complete = true;
+        this.playing = false;
       }
     }
   }

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -59,9 +59,8 @@ export class SpotifyComponent implements OnInit {
 
   async loadNowPlaying() {
     const nowPlaying: PlaybackState | false = await this.spotifyService.getNowPlaying();
-    if (!nowPlaying) {
+    if (!nowPlaying || !nowPlaying.is_playing) {
       this.complete = true;
-      this.active = false;
       return;
     } else {
       if (nowPlaying.item.type == "track") {

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -4,7 +4,8 @@ import { SpotifyService } from '../services/spotify.service';
 import { BotConnectorService } from '../services/bot-connector.service';
 import { PlaybackState, Track } from '@spotify/web-api-ts-sdk';
 
-const LOOP_INTERVAL = 5 * 1000; // 5 seconds
+const SONG_UPDATE_LOOP_INTERVAL: number = 5 * 1000; // 5 seconds
+const PROGRESS_UPDATE_LOOP_INTERVAL: number = 1 * 1000; // 1 second
 
 @Component({
   selector: 'app-spotify',
@@ -63,14 +64,14 @@ export class SpotifyComponent implements OnInit {
   async nowPlayingLoop() {
     if (this.active) {
       await this.loadNowPlaying();
-      setTimeout(() => this.nowPlayingLoop(), LOOP_INTERVAL);
+      setTimeout(() => this.nowPlayingLoop(), SONG_UPDATE_LOOP_INTERVAL);
     }
   }
 
   async progressLoop() {
     if (this.active) {
       await this.updateProgress();
-      setTimeout(() => this.progressLoop(), 1000);
+      setTimeout(() => this.progressLoop(), PROGRESS_UPDATE_LOOP_INTERVAL);
     }
   }
 

--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -28,8 +28,8 @@ export class SpotifyComponent implements OnInit {
   constructor(private botService: BotConnectorService, private spotifyService: SpotifyService) {
   }
 
-  complete: boolean = true;
-  active: boolean = false;
+  complete: boolean = true; // Whether or not to show the Overlay
+  active: boolean = false; // Whether or not to continue the loop
   albumCoverURL: string = "";
   songTitle: string = "";
   songArtist: string = "";
@@ -41,16 +41,16 @@ export class SpotifyComponent implements OnInit {
           await this.spotifyService.login();
           this.active = true;
           this.nowPlayingLoop();
-        } else if (data.name === "logoff" && data.value == true) {
-          await this.spotifyService.logoff();
-          this.active = false;
+        } else if (data.name === "stop" && data.value == true) {
+          await this.spotifyService.stop();
           this.complete = true;
+          this.active = false;
         }
       }
     });
   }
 
-  async nowPlayingLoop() {
+  async nowPlayingLoop() { // Check for currently playing song every LOOP_INTERVAL millis
     if (this.active) {
       await this.loadNowPlaying();
       setTimeout(() => this.nowPlayingLoop(), LOOP_INTERVAL);
@@ -58,13 +58,14 @@ export class SpotifyComponent implements OnInit {
   }
 
   async loadNowPlaying() {
-    const nowPlaying: PlaybackState | "AuthError" = await this.spotifyService.getNowPlaying();
-    if (nowPlaying == "AuthError") {
+    const nowPlaying: PlaybackState | false = await this.spotifyService.getNowPlaying();
+    if (!nowPlaying) {
       this.complete = true;
+      this.active = false;
       return;
     } else {
       if (nowPlaying.item.type == "track") {
-        const item = nowPlaying.item as Track;
+        const item = nowPlaying.item as Track; // Needed because TS complains that we might be working with a "Episode" otherwise
 
         const albumArt = item.album.images.pop();
         this.albumCoverURL = albumArt ? albumArt.url : "assets/hoojsheesh.png"; // Assume self-composed for local files, which will return no album art

--- a/src/app/stream-layout/stream-layout.component.html
+++ b/src/app/stream-layout/stream-layout.component.html
@@ -12,6 +12,7 @@
     <app-poll-render></app-poll-render>
     <app-vod-review style="background-image: url('assets/TextBox_Container.png');"></app-vod-review>
     <app-sub-goal></app-sub-goal>
+    <app-spotify></app-spotify>
     <ng-container *ngIf="themeService.getMiddleImage().split('.')[1] === 'mp4'">
         <video id="footer" loop autoplay>
             <source src="{{themeService.getMiddleImage()}}" type="video/mp4">

--- a/src/app/stream-layout/stream-layout.component.scss
+++ b/src/app/stream-layout/stream-layout.component.scss
@@ -109,6 +109,15 @@ app-sub-goal {
     z-index: 1002;
 }
 
+app-spotify {
+    width: 274px;
+    height: 74px;
+    display: block;
+    position: absolute;
+    bottom: 154px;
+    left: 0px;
+}
+
 img#footer {
     position: absolute;
     bottom: 0px;

--- a/src/app/testing/testing.component.html
+++ b/src/app/testing/testing.component.html
@@ -17,5 +17,5 @@
     <button (click)="endPoll()">End Poll</button>
     <button (click)="sendSubscription()">Send Test Subscription</button>
     <button (click)="spotifyLogin()">Spotify Login</button>
-    <button (click)="spotifyLogoff()">Spotify Logoff</button>
+    <button (click)="spotifyStop()">Spotify Stop</button>
 </div>

--- a/src/app/testing/testing.component.html
+++ b/src/app/testing/testing.component.html
@@ -16,4 +16,6 @@
     <button (click)="startPoll()">Start Poll</button>
     <button (click)="endPoll()">End Poll</button>
     <button (click)="sendSubscription()">Send Test Subscription</button>
+    <button (click)="spotifyLogin()">Spotify Login</button>
+    <button (click)="spotifyLogoff()">Spotify Logoff</button>
 </div>

--- a/src/app/testing/testing.component.ts
+++ b/src/app/testing/testing.component.ts
@@ -79,6 +79,22 @@ export class TestingComponent implements OnInit {
     });
   }
 
+  spotifyLogin() {
+    this.botConnectorService.sendToStream("streamdeck", {
+      "type": "spotify",
+      "name": "login",
+      "value": true,
+    })
+  }
+
+  spotifyLogoff() {
+    this.botConnectorService.sendToStream("streamdeck", {
+      "type": "spotify",
+      "name": "logoff",
+      "value": true,
+    })
+  }
+
   ngOnInit(): void {
     this.sendFakeMessageOnTimer();
   }

--- a/src/app/testing/testing.component.ts
+++ b/src/app/testing/testing.component.ts
@@ -87,10 +87,10 @@ export class TestingComponent implements OnInit {
     })
   }
 
-  spotifyLogoff() {
+  spotifyStop() {
     this.botConnectorService.sendToStream("streamdeck", {
       "type": "spotify",
-      "name": "logoff",
+      "name": "stop",
       "value": true,
     })
   }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,5 +4,7 @@ export const environment = {
   hostURL: "new-overlay.woohooj.in",
   naDiscordRoleID: 1045126121928282122,
   t3DiscordRoleID: 1036807951484203099,
-  giftedT3DiscordRoleID: 1045466382470484040
+  giftedT3DiscordRoleID: 1045466382470484040,
+  spotifyClientID: "FILL_ME",
+  spotifyRedirectURL: "BASE_OVERLAY_URL"
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,7 +8,9 @@ export const environment = {
   hostURL: "",
   naDiscordRoleID: 0,
   t3DiscordRoleID: 0,
-  giftedT3DiscordRoleID: 0
+  giftedT3DiscordRoleID: 0,
+  spotifyClientID: "0",
+  spotifyRedirectURL: "http://?"
 };
 
 /*


### PR DESCRIPTION
This PR implements base functionality for Spotify integration to display the currently playing song.
At the moment it uses the same overlay position and size as the VOD Review overlay, since those two shouldn't conflict and because I'm not a UI designer. I'll leave the placing and CSS stuff to you/your designer.
Adds two new "streamdeck functions" so to say, `spotify login` and `spotify stop`. Login triggers the OAuth process (or enable the functionality if we are logged in (since the browser refreshes we need to hit it again after OAuth is done)). Stop simply disables the functionality but does not log us out to prevent OAuth spam.
We poll the API every 5 seconds at the moment to not trip ratelimits. This amount should be fine but since Spotify doesn't give us proper ratelimit information we'll just have to see. [See it in action](https://youtu.be/dwGkk4CUxr8).

Two new environment variables are required for this:
spotifyClientID: The client ID of the Spotify App. Completely safe to use, does not grant any kind of access.
spotifyRedirectURL: The URL the Spotify SDK should redirect to. Base overlay URL in my testing.

Requirements:
 - Spotify Dev App: https://developer.spotify.com/dashboard
    Personal Use/Development Mode is perfectly fine, since only one will be allowed to log in.
    The only API we need to check is "Web API".
    Your Spotify email must be in the "User Management" list of allowed users.
    Redirect URL points to the base overlay URL (at least in my tests), e.g. "http://new-overlay.localhost:4200/testing?name=Lena" for me.
 - TypeScript upgrade (included, run `npm ci`)
 - Spotify TS SDK (same as above)