### PR TITLE
Potential fix for scroll breaking after VOD Reviews

### DIFF
--- a/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
+++ b/src/app/spotify-nowplaying/spotify-nowplaying.component.ts
@@ -59,6 +59,7 @@ export class SpotifyComponent implements OnInit {
         } else if (data.name === "stop" && data.value == true) {
           await this.spotifyService.stop();
           this.playing = false;
+          this.elementsReady = false;
           this.active = false;
         }
       }
@@ -70,6 +71,7 @@ export class SpotifyComponent implements OnInit {
         this.vodReviewActive = false;
       } else { // Else block rendering
         this.playing = false;
+        this.elementsReady = false;
         this.vodReviewActive = true;
       }
     });
@@ -93,6 +95,7 @@ export class SpotifyComponent implements OnInit {
   async loadNowPlaying() {
     if (this.vodReviewActive) {
       this.playing = false;
+      this.elementsReady = false;
       return;
     }
 
@@ -107,6 +110,7 @@ export class SpotifyComponent implements OnInit {
 
     if (!nowPlaying || !nowPlaying.is_playing) {
       this.playing = false;
+      this.elementsReady = false;
       return;
     } else {
       if (nowPlaying.item.type == "track") {
@@ -134,6 +138,7 @@ export class SpotifyComponent implements OnInit {
         this.playing = true;
       } else {
         this.playing = false;
+        this.elementsReady = false;
       }
     }
   }


### PR DESCRIPTION
I suspect that VOD Reviews break something in angular where the querySelectors break after the spotify element gets hidden.