### PR TITLE
Changes to Emote Popups and Animation Component

### DIFF
--- a/src/app/animation/animation-host.component.html
+++ b/src/app/animation/animation-host.component.html
@@ -1,0 +1,5 @@
+<div class="animation-display">
+    <div class="vertical">
+        <ng-template animationSpace></ng-template>
+    </div>
+</div>

--- a/src/app/animation/animation-host.component.ts
+++ b/src/app/animation/animation-host.component.ts
@@ -1,0 +1,55 @@
+import { Component, Directive, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+import { BotConnectorService } from '../services/bot-connector.service';
+import { AnimationComponent } from './animation.component';
+
+@Directive({
+    selector: '[animationSpace]',
+})
+export class AnimationHostDirective {
+    constructor(public viewContainerRef: ViewContainerRef) { }
+}
+
+@Component({
+  selector: 'app-animation-host',
+  templateUrl: './animation-host.component.html',
+  styleUrls: ['./animation.component.scss']
+})
+export class AnimationHostComponent implements OnInit {
+  
+  @ViewChild(AnimationHostDirective, { static: true }) animationSpace!: AnimationHostDirective;
+
+  constructor(private botService: BotConnectorService) { }
+
+  ngOnInit(): void {
+    this.botService.getStream('streamdeck').subscribe(data => {
+      if (data.type === "animation") {
+
+        const viewContainerRef = this.animationSpace.viewContainerRef;
+        const componentRef = viewContainerRef.createComponent<AnimationComponent>(AnimationComponent);
+
+        let source = data.source;
+        
+        //typescript compiler is drunk, just leave it
+        if ("canParse" in URL && typeof URL.canParse == "function") {
+            if (URL.canParse(source)) {
+                let url = new URL(source);
+                //adding a random bit of get query so the browser doesn't try to cache our stuff
+                url.searchParams.append("random", Date.now().toString());
+                source = url.href;
+            }
+            
+        }
+
+        componentRef.instance.source = source;
+        componentRef.instance.contentLoadedCallack = function() {
+            setTimeout(() => {
+                componentRef.destroy();
+            }, data.duration);
+        }
+      }
+    });
+  }
+
+}
+
+

--- a/src/app/animation/animation.component.html
+++ b/src/app/animation/animation.component.html
@@ -1,7 +1,6 @@
-<ng-container *ngIf="display">
-    <div class="animation-display">
-        <div class="vertical">
-            <img class="animation" src="{{source}}"/>
-        </div>
-    </div>
-</ng-container>
+<div class="">
+    <img [hidden]="!image" class="animation" src="{{source}}" (load)="_imageLoaded()">
+    <video #videoPlayer [hidden]="!video" class="animation" autoplay muted>
+        <source src="{{source}}">
+    </video>
+</div>

--- a/src/app/animation/animation.component.ts
+++ b/src/app/animation/animation.component.ts
@@ -1,27 +1,48 @@
-import { Component, OnInit } from '@angular/core';
-import { BotConnectorService } from '../services/bot-connector.service';
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
 
 @Component({
   selector: 'app-animation',
   templateUrl: './animation.component.html',
   styleUrls: ['./animation.component.scss']
 })
-export class AnimationComponent implements OnInit {
-  display: boolean = false;
+export class AnimationComponent implements OnDestroy, AfterViewInit {
   source: string = "";
+  image = false;
+  video = false;
+  playing = false;
 
-  constructor(private botService: BotConnectorService) { }
+  contentLoadedCallack!: Function;
 
-  ngOnInit(): void {
-    this.botService.getStream('streamdeck').subscribe(data => {
-      if (data.type === "animation") {
-        this.display = true;
-        this.source = data.source;
+  @ViewChild('videoPlayer') videoPlayer!: ElementRef;
 
-        setTimeout(() => {
-          this.display = false;
-        }, data.duration * 1000);
-      }
-    });
+  constructor(public viewContainerRef: ViewContainerRef) { }
+
+  ngAfterViewInit(): void {
+    this.videoPlayer.nativeElement.onloadeddata = this._videoLoaded.bind(this);
+  }
+
+  ngOnDestroy(): void {
+    this.playing = false;
+    this.image = false;
+    this.video = false;
+    this.source = "";
+  }
+
+  _imageLoaded() {
+    if (this.playing) return;
+    this.playing = true;
+    this.image = true;
+    this.contentLoaded();
+  }
+
+  _videoLoaded() {
+    if (this.playing) return;
+    this.playing = true;
+    this.video = true;
+    this.contentLoaded();
+  }
+
+  contentLoaded(): void {
+    this.contentLoadedCallack();
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { EmotePopupsComponent } from './emote-popups/emote-popups.component';
 import { EmotePopupsDirective } from './emote-popups/emote-popups-directive';
 import { EmotePopupIconComponent } from './emote-popup-icon/emote-popup-icon.component';
 import { EmotePopupsComponentMultiple } from './emote-popups/subclasses/emote-popups-multiple.component';
+import { AnimationHostComponent, AnimationHostDirective } from './animation/animation-host.component';
 
 @NgModule({
   declarations: [
@@ -84,6 +85,8 @@ import { EmotePopupsComponentMultiple } from './emote-popups/subclasses/emote-po
     ConnectFourComponent,
     TeamLogoComponent,
     AnimationComponent,
+    AnimationHostComponent,
+    AnimationHostDirective,
     AiChatInteractorComponent,
     ChatMessageComponent,
     ViewerComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,6 +46,7 @@ import { SpotifyComponent } from './spotify-nowplaying/spotify-nowplaying.compon
 import { EmotePopupsComponent } from './emote-popups/emote-popups.component';
 import { EmotePopupsDirective } from './emote-popups/emote-popups-directive';
 import { EmotePopupIconComponent } from './emote-popup-icon/emote-popup-icon.component';
+import { EmotePopupsComponentMultiple } from './emote-popups/subclasses/emote-popups-multiple.component';
 
 @NgModule({
   declarations: [
@@ -88,6 +89,7 @@ import { EmotePopupIconComponent } from './emote-popup-icon/emote-popup-icon.com
     ViewerComponent,
     SpotifyComponent,
     EmotePopupsComponent,
+    EmotePopupsComponentMultiple,
     EmotePopupsDirective,
     EmotePopupIconComponent
   ],

--- a/src/app/emote-popup-icon/emote-popup-icon.component.ts
+++ b/src/app/emote-popup-icon/emote-popup-icon.component.ts
@@ -55,7 +55,7 @@ export class EmotePopupIconComponent implements OnInit, AfterViewInit {
    */
   getRandomJumpHeight(): number {
     var x = Math.random() * 100;
-    x = Math.min(x, 70); //70 is minimum jump height, otherwise it looks bad
+    x = Math.min(x, 50); //70 is minimum jump height, otherwise it looks bad
     return Math.round(x);
   }
 }

--- a/src/app/emote-popups/subclasses/emote-popups-multiple.component.ts
+++ b/src/app/emote-popups/subclasses/emote-popups-multiple.component.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+import { EmotePopupsComponent, EmoteProperties } from '../emote-popups.component';
+
+@Component({
+  selector: 'app-emote-popups-multiple',
+  templateUrl: '../emote-popups.component.html',
+  styleUrls: ['../emote-popups.component.scss']
+})
+export class EmotePopupsComponentMultiple extends EmotePopupsComponent {
+
+  protected amount = 0;
+  protected timeframe = 10 * 1000;
+  protected emoteUsages: { [id: string] : number[] } = {};
+
+  override adjustEmoteProperties(properties: EmoteProperties): void {
+    let amountInLastTimeframe = this.findAmountUsedLastTimeframe(properties.asset);
+    properties.amount = this.amountFunction(amountInLastTimeframe);
+  }
+
+  findAmountUsedLastTimeframe(emote: string): number {
+    let now = Date.now();
+    let latestTimestampAcceptable = now - this.timeframe;
+
+    let usages = this.emoteUsages[emote];
+    if (!usages) {
+      usages = [];
+    }
+    usages = usages.filter((e) => {
+      return e >= latestTimestampAcceptable;
+    });
+    let result = usages.length;
+
+    usages.push(now);
+    this.emoteUsages[emote] = usages;
+
+    return result;
+  }
+
+  amountFunction(amountInLastTimeframe: number): number {
+    let hist = amountInLastTimeframe;
+
+    let a = 2, b = 2, c = -0.4, d = 1, e = 1;
+    let result = Math.pow(a, c*hist+d) * b + e;
+
+    result = Math.round(result);
+    
+    return result;
+  }
+
+}

--- a/src/app/stream-layout/stream-layout.component.html
+++ b/src/app/stream-layout/stream-layout.component.html
@@ -6,7 +6,7 @@
     <app-chat [mainChatOverlay]="true" width="274px" height="778px" left="0px" bottom="228px" position="absolute"></app-chat>
     <app-team-logo></app-team-logo>
     <app-ai-chat-interactor></app-ai-chat-interactor>
-    <app-animation></app-animation>
+    <app-animation-host></app-animation-host>
     <app-cool></app-cool>
     <app-prediction-render></app-prediction-render>
     <app-poll-render></app-poll-render>

--- a/src/app/stream-layout/stream-layout.component.html
+++ b/src/app/stream-layout/stream-layout.component.html
@@ -23,6 +23,7 @@
     </ng-container>
     <img id="left" src="{{themeService.getLeftImage()}}" />
     <app-emote-popups id="bottomEdgeEmotePopupContainer" name="bottomEdge" direction="up"></app-emote-popups>
+    <app-emote-popups-multiple id="bottomEdgeEmotePopupContainer" name="bottomEdgeMultiple" direction="up"></app-emote-popups-multiple>
     <app-emote-popups id="leftEdgeEmotePopupContainer" name="leftEdge" direction="right"></app-emote-popups>
     <app-emote-popups id="topEdgeEmotePopupContainer" name="topEdge" direction="down"></app-emote-popups>
     <app-emote-popups id="rightEdgeEmotePopupContainer" name="rightEdge" direction="left"></app-emote-popups>

--- a/src/app/stream-layout/stream-layout.component.scss
+++ b/src/app/stream-layout/stream-layout.component.scss
@@ -138,8 +138,8 @@ video#footer {
 
 #bottomEdgeEmotePopupContainer {
     position: absolute;
-    width: 1606px;  //beware overflow due to emote size
-    height: 20%;
+    width: 1566px;  //beware overflow due to emote size
+    height: 30%;
     left: 274px;
     bottom: 154px;
 }
@@ -147,15 +147,15 @@ video#footer {
 #leftEdgeEmotePopupContainer {
     position: absolute;
     width: 30%;
-    height: 892px;
-    bottom: 194px;  //beware overflow due to emote size
+    height: 852px;
+    bottom: 234px;  //beware overflow due to emote size
     left: 274px;
 }
 
 #topEdgeEmotePopupContainer {
     position: absolute;
-    width: 1606px;  //beware overflow due to emote size
-    height: 20%;
+    width: 1566px;  //beware overflow due to emote size
+    height: 30%;
     top: 0px;  
     left: 274px;
 }
@@ -163,7 +163,7 @@ video#footer {
 #rightEdgeEmotePopupContainer {
     position: absolute;
     width: 30%;
-    height: 892px;
-    bottom: 194px;  //beware overflow due to emote size
+    height: 852px;
+    bottom: 234px;  //beware overflow due to emote size
     right: 0px;
 }

--- a/src/app/stream-layout/stream-layout.component.scss
+++ b/src/app/stream-layout/stream-layout.component.scss
@@ -18,7 +18,7 @@ app-ai-chat-interactor {
     z-index: 5001;
 }
 
-app-animation {
+app-animation-host {
     position: absolute;
     top: 0px;
     // Centered on capture card, not the screen

--- a/src/app/testing/testing.component.ts
+++ b/src/app/testing/testing.component.ts
@@ -164,6 +164,8 @@ export class TestingComponent implements OnInit {
       randomMessage.content = "" + (Math.floor(Math.random() * 4) + 1);
     }
 
+    randomMessage.content += "🦀";
+
     return randomMessage;
   }
 


### PR DESCRIPTION
This request contains two unrelated features.

First, an update of the emote popups.
- Emotes jump higher now so the bigger emotes don't get clipped off by the bottom of the overlay
- Added a new emote zone that adjusts the amount of emotes that jump based of their recent usage (zone location **bottomEdgeMultiple**). This was requested by Penflash.
- Made the entire emote functionality more expandable for the future

Secondly, I adjusted the animation-component. This happened after Zendikar voiced some bugs with the previous implementation.
- The animation-component was renamed to animation-host-component
- The animation feature now spawns a new subcomponent that contains the image or video (akin to how the emote popups work)
- The duration parameter is now considered to be in miliseconds
- Added a _video_ tag so both image and video resources are supported
- The content should no longer be cached to prevent an animation looping in the background
- Feature waits until resource is loaded before starting display (this is more interesting if the content is loaded from a server on another continent for example, since I experienced some big lagspikes in animated APNGs or GIFs)